### PR TITLE
Add Cloud Agent development environment

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,12 @@
+{
+  "name": "Vidik (agora)",
+  "install": "bash .cursor/install.sh",
+  "start": "bash .cursor/start.sh",
+  "terminals": [
+    {
+      "name": "api-dev-server",
+      "command": "export PATH=\"$HOME/.local/bin:$PATH\"; cd api && uv run fastapi dev app/main.py --host 0.0.0.0 --port 8000"
+    }
+  ],
+  "ports": [8000]
+}

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -8,5 +8,5 @@
       "command": "export PATH=\"$HOME/.local/bin:$PATH\"; cd api && uv run fastapi dev app/main.py --host 0.0.0.0 --port 8000"
     }
   ],
-  "ports": [8000]
+  "ports": [{ "name": "api", "port": 8000 }]
 }

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Idempotent repository bootstrap for the Vidik (agora) monorepo.
+# Installs toolchains and Python dependencies for the `scraper` and `api` services.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# --- System packages (guarded; normally already present in the base snapshot) ---
+if ! command -v psql >/dev/null 2>&1 || ! dpkg -s build-essential >/dev/null 2>&1; then
+  sudo apt-get update
+  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    build-essential postgresql postgresql-contrib curl git ca-certificates
+fi
+
+# --- uv (Python package/toolchain manager) ---
+if ! command -v uv >/dev/null 2>&1; then
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
+export PATH="$HOME/.local/bin:$PATH"
+# Expose uv on the system PATH so `start` and terminals find it without shell hacks.
+sudo ln -sf "$HOME/.local/bin/uv" /usr/local/bin/uv
+sudo ln -sf "$HOME/.local/bin/uvx" /usr/local/bin/uvx
+
+# --- Local development environment files (real secrets injected as env vars win) ---
+# `dotenv` does not override existing environment variables, so providing real
+# OPENAI_API_KEY / DATABASE_URL / etc. as Cloud Agent secrets overrides these defaults.
+if [ ! -f scraper/.env ]; then
+  cat > scraper/.env <<'EOF'
+APP_ENV=development
+DATABASE_URL=postgresql://vidik:vidik@localhost:5432/vidik
+OPENAI_API_KEY=dev-placeholder-not-used-offline
+OPENROUTER_API_KEY=dev-placeholder-not-used-offline
+PEXELS_API_KEY=dev-placeholder-not-used-offline
+EOF
+fi
+if [ ! -f api/.env ]; then
+  cat > api/.env <<'EOF'
+DATABASE_URL=postgresql://vidik:vidik@localhost:5432/vidik
+HOST=0.0.0.0
+PORT=8000
+ENVIRONMENT=development
+DEBUG=true
+APP_ENV=development
+EOF
+fi
+
+# --- Python dependencies (uv manages the required Python 3.13 automatically) ---
+(cd scraper && uv sync --group dev --group test)
+(cd api && uv sync)
+
+echo "install.sh: complete"

--- a/.cursor/start.sh
+++ b/.cursor/start.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Per-boot reconciliation for the Vidik (agora) development environment.
+# Brings up local Postgres, ensures the dev role/database and schema exist, and
+# seeds the news providers so the API has data to serve. Safe to run repeatedly.
+set -uo pipefail
+
+export PATH="$HOME/.local/bin:$PATH"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+PG_VER="$(ls /usr/lib/postgresql/ 2>/dev/null | sort -n | tail -1)"
+PG_VER="${PG_VER:-16}"
+
+# Start the Postgres cluster if it is not already online (no systemd in the VM).
+if ! sudo pg_lsclusters -h 2>/dev/null | awk '{print $4}' | grep -q online; then
+  sudo pg_ctlcluster "$PG_VER" main start || true
+fi
+
+# Wait for Postgres to accept connections.
+for _ in $(seq 1 30); do
+  if pg_isready -h localhost -p 5432 >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+
+# Ensure the dev role and database exist (idempotent).
+sudo -u postgres psql -tAc "SELECT 1 FROM pg_roles WHERE rolname='vidik'" | grep -q 1 \
+  || sudo -u postgres psql -c "CREATE ROLE vidik LOGIN PASSWORD 'vidik';"
+sudo -u postgres psql -tAc "SELECT 1 FROM pg_database WHERE datname='vidik'" | grep -q 1 \
+  || sudo -u postgres createdb -O vidik vidik
+sudo -u postgres psql -c "GRANT ALL PRIVILEGES ON DATABASE vidik TO vidik;" >/dev/null 2>&1
+
+# Bootstrap the schema from the current ORM models and mark Alembic at head.
+# The initial Alembic migration is an empty stub (the baseline tables predate
+# Alembic), so a fresh database is built from the models and then stamped.
+cd "$REPO_ROOT/scraper"
+uv run python -c "from app.database.schema import Base, engine; Base.metadata.create_all(engine)"
+uv run alembic stamp head >/dev/null 2>&1 || true
+
+# Seed the news providers (idempotent upsert) so the API returns data.
+uv run python -c "
+from app.database.services import NewsProviderService
+from app.providers.providers import PROVIDERS
+NewsProviderService.sync_providers(PROVIDERS)
+print(f'start.sh: seeded {len(PROVIDERS)} news providers')
+"
+
+echo "start.sh: complete (postgres online, schema ready, providers seeded)"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a Cloud Agent development environment for the Vidik (`agora`) monorepo so both the `scraper` and `api` services are usable end-to-end out of the box.

New files under `.cursor/`:
- `environment.json` — declares the `install`/`start` scripts, an `api-dev-server` terminal, and exposes port `8000`.
- `install.sh` — idempotent bootstrap: ensures system packages (`build-essential`, `postgresql`) are present, installs `uv`, writes dev `.env` files (only if missing), and runs `uv sync` for `scraper` (with `dev`+`test` groups) and `api`. `uv` provisions the required Python 3.13 automatically.
- `start.sh` — per-boot reconciliation: starts the local Postgres cluster, ensures the `vidik` role/database exist, bootstraps the schema from the ORM models, stamps Alembic to head, and seeds the 27 news providers.

## Notes

- The initial Alembic migration is an empty stub (the baseline `article`/`news_provider` tables predate Alembic), so a fresh database cannot be built by `alembic upgrade head` alone. `start.sh` therefore builds the schema from the current ORM models via `Base.metadata.create_all()` and stamps Alembic to head; `alembic check` then reports no pending operations.
- Dev `.env` files use local defaults and placeholder API keys. Because `python-dotenv` does not override existing environment variables, real secrets (e.g. `OPENAI_API_KEY`, `DATABASE_URL`) injected as Cloud Agent secrets take precedence. `.env` files are gitignored and not committed.

## Validation

- `scraper` test suite: 52 passed.
- Postgres schema bootstrap + Alembic stamp: `alembic check` reports no new operations.
- Cross-service end-to-end: `scraper` seeds 27 providers into Postgres → `api` `GET /providers` returns all 27.
- `install.sh` and `start.sh` verified idempotent (run twice; `start.sh` also validated from a cold state with no cluster/database).
- Verified in a fresh Cloud Agent booted from a prebuilt environment build: toolchains, venvs, DB, tests, and both API endpoints all passed.

### Demo — `GET /providers` served from Postgres via Swagger UI

[vidik_api_providers_swagger_demo.mp4](https://cursor.com/agents/bc-470146db-89f9-4d56-92a4-99209916589c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fvidik_api_providers_swagger_demo.mp4)

[GET /providers returns HTTP 200 with 27 providers](https://cursor.com/agents/bc-470146db-89f9-4d56-92a4-99209916589c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fvidik_providers_200_response.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-470146db-89f9-4d56-92a4-99209916589c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-470146db-89f9-4d56-92a4-99209916589c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

